### PR TITLE
Adjust correlator performance

### DIFF
--- a/services/delivery/src/deliver/get-ad.js
+++ b/services/delivery/src/deliver/get-ad.js
@@ -39,7 +39,7 @@ module.exports = async (correlator, adunit, date) => {
   const correlated = await db.findOne('correlators', { value: correlator });
   if (correlated) {
     // Return the correlated item's ad src/url
-    const ad = await db.strictFindActiveById('ads', correlated.adId, { projection: { 'image.src': 1, url: 1 } });
+    const ad = await db.findById('ads', correlated.adId, { projection: { 'image.src': 1, url: 1 } });
     return {
       ...correlated,
       src: ad.image.src,

--- a/services/delivery/src/deliver/get-ad.js
+++ b/services/delivery/src/deliver/get-ad.js
@@ -39,7 +39,15 @@ const updateCorrelator = async (correlator, ad, lineitemId) => {
  */
 module.exports = async (correlator, adunit, date) => {
   const correlated = await db.findOne('correlators', { value: correlator });
-  if (correlated) return correlated;
+  if (correlated) {
+    // Return the correlated item's ad src/url
+    const ad = await db.strictFindActiveById('ads', correlated.adId, { projection: { 'image.src': 1, url: 1 } });
+    return {
+      ...correlated,
+      src: ad.image.src,
+      url: ad.url,
+    };
+  }
 
   const cursor = await getSchedules(adunit._id, date);
   const schedules = await cursor.toArray();

--- a/services/delivery/src/deliver/get-ad.js
+++ b/services/delivery/src/deliver/get-ad.js
@@ -18,11 +18,9 @@ const getSchedules = (adunitId, date) => db.aggregate('schedules', [
  * @param {*} ad
  */
 const updateCorrelator = async (correlator, ad, lineitemId) => {
-  const { _id: adId, src, url } = ad;
+  const { _id: adId } = ad;
   return db.updateOne('correlators', { value: correlator }, {
     $set: {
-      src,
-      url,
       adId,
       lineitemId,
     },

--- a/services/delivery/src/deliver/index.js
+++ b/services/delivery/src/deliver/index.js
@@ -1,3 +1,4 @@
+const { URL } = require('url');
 const normalizeQuery = require('../utils/normalize-query');
 const createCorrelator = require('../utils/create-correlator');
 const getAd = require('./get-ad');

--- a/services/delivery/src/env.js
+++ b/services/delivery/src/env.js
@@ -19,6 +19,7 @@ module.exports = cleanEnv(process.env, {
   MONGO_DSN: nonemptystr({ desc: 'The MongoDB DSN to connect to.' }),
   INTERNAL_PORT: port({ desc: 'The internal port that express will run on.', default: 80 }),
   EXTERNAL_PORT: port({ desc: 'The external port that express is exposed on.', default: 80 }),
+  CDN_HOST: nonemptystr({ desc: 'The CDN hostname for serving ad images.', default: 'cdn.email-x.parameter1.com' }),
   NEW_RELIC_ENABLED: bool({ desc: 'Whether New Relic is enabled.', default: true, devDefault: false }),
   NEW_RELIC_LICENSE_KEY: nonemptystr({ desc: 'The license key for New Relic.', devDefault: '(unset)' }),
 });

--- a/services/delivery/src/routes/data.js
+++ b/services/delivery/src/routes/data.js
@@ -26,11 +26,7 @@ module.exports = (app) => {
       deployment,
       ad,
       advertiser,
-      correlated: {
-        ...correlated,
-        src: ad.image.src,
-        url: ad.url,
-      },
+      correlated,
     });
   }));
 };

--- a/services/delivery/src/routes/data.js
+++ b/services/delivery/src/routes/data.js
@@ -26,7 +26,11 @@ module.exports = (app) => {
       deployment,
       ad,
       advertiser,
-      correlated,
+      correlated: {
+        ...correlated,
+        src: ad.image.src,
+        url: ad.url,
+      },
     });
   }));
 };

--- a/services/delivery/src/routes/image.js
+++ b/services/delivery/src/routes/image.js
@@ -1,7 +1,6 @@
 const { URL } = require('url');
 const { asyncRoute, getAdUnit, cdnHostnameFor } = require('../utils');
 const deliver = require('../deliver');
-const db = require('../db');
 
 module.exports = (app) => {
   app.get('/image/:adunitid', asyncRoute(async (req, res) => {
@@ -14,7 +13,7 @@ module.exports = (app) => {
 
     const cdnHostname = await cdnHostnameFor(adunit.publisherId);
 
-    const { image: { src } } = await db.strictFindActiveById('ads', correlated.adId, { projection: { 'image.src': 1 } });
+    const { src } = correlated;
     if (cdnHostname) {
       // A custom CDN host has been configured. Adjust the redirect.
       const url = new URL(src);

--- a/services/delivery/src/routes/image.js
+++ b/services/delivery/src/routes/image.js
@@ -1,5 +1,4 @@
-const { URL } = require('url');
-const { asyncRoute, getAdUnit, cdnHostnameFor } = require('../utils');
+const { asyncRoute, getAdUnit } = require('../utils');
 const deliver = require('../deliver');
 
 module.exports = (app) => {
@@ -11,15 +10,7 @@ module.exports = (app) => {
     const correlated = await deliver(adunit, query, 'image', req);
     if (!correlated) return res.status(204).send();
 
-    const cdnHostname = await cdnHostnameFor(adunit.publisherId);
-
     const { src } = correlated;
-    if (cdnHostname) {
-      // A custom CDN host has been configured. Adjust the redirect.
-      const url = new URL(src);
-      url.hostname = cdnHostname;
-      return res.redirect(302, `${url}`);
-    }
     return res.redirect(302, src);
   }));
 };

--- a/services/delivery/src/routes/image.js
+++ b/services/delivery/src/routes/image.js
@@ -1,6 +1,7 @@
 const { URL } = require('url');
 const { asyncRoute, getAdUnit, cdnHostnameFor } = require('../utils');
 const deliver = require('../deliver');
+const db = require('../db');
 
 module.exports = (app) => {
   app.get('/image/:adunitid', asyncRoute(async (req, res) => {
@@ -13,7 +14,7 @@ module.exports = (app) => {
 
     const cdnHostname = await cdnHostnameFor(adunit.publisherId);
 
-    const { src } = correlated;
+    const { image: { src } } = await db.strictFindActiveById('ads', correlated.adId, { projection: { 'image.src': 1 } });
     if (cdnHostname) {
       // A custom CDN host has been configured. Adjust the redirect.
       const url = new URL(src);

--- a/services/delivery/src/utils/cdn-hostname-for.js
+++ b/services/delivery/src/utils/cdn-hostname-for.js
@@ -1,8 +1,9 @@
 const db = require('../db');
+const { CDN_HOST } = require('../env');
 
 module.exports = async (publisherId) => {
   const { cdnHostname } = await db.strictFindById('publishers', publisherId, {
     projection: { cdnHostname: 1 },
   });
-  return cdnHostname;
+  return cdnHostname || CDN_HOST;
 };

--- a/services/graphql/src/mongoose/schema/ad.js
+++ b/services/graphql/src/mongoose/schema/ad.js
@@ -252,16 +252,6 @@ schema.pre('save', async function updateEvents() {
   }
 });
 
-schema.pre('save', async function updateCorrelators() {
-  if (this.isModified('url') || this.isModified('image.src')) {
-    const { url } = this;
-    const { serveSrc: src } = this.image;
-    connection.model('correlator').updateMany({ adId: this._id }, {
-      $set: { url, src },
-    }).catch(e => logError(e));
-  }
-});
-
 schema.post('save', async function updateLineItem() {
   const lineitem = await connection.model('lineitem').findById(this.lineitemId);
   return lineitem ? lineitem.save() : null;

--- a/services/graphql/src/mongoose/schema/correlator.js
+++ b/services/graphql/src/mongoose/schema/correlator.js
@@ -2,8 +2,6 @@ const { Schema } = require('mongoose');
 
 const schema = new Schema({
   value: String,
-  src: String,
-  url: String,
   adId: Schema.Types.ObjectId,
   lineitemId: Schema.Types.ObjectId,
 });


### PR DESCRIPTION
Removes ad `url` and `image.src` from the `correlator` model. When the ad is not currently available (aka, the correlator has already been inserted), these values will be retrieved from the associated `adId` and returned, keeping the signature identical.

This prevents a specific use-case causing significant load when updating an ad with a large number of existing correlators.