### PR TITLE
Only set hostname if a correlator is returned

### DIFF
--- a/services/delivery/src/deliver/index.js
+++ b/services/delivery/src/deliver/index.js
@@ -29,7 +29,7 @@ module.exports = async (adunit, query, type, req) => {
   });
   const correlated = await getAd(correlator, adunit, date);
   const cdnHostname = await cdnHostnameFor(adunit.publisherId);
-  if (cdnHostname) {
+  if (correlated && cdnHostname) {
     // A custom CDN host has been configured. Adjust the URL.
     const url = new URL(correlated.src);
     url.hostname = cdnHostname;


### PR DESCRIPTION
A correlator is only returned if an ad was returned -- update logic to prevent property access from `null` in this condition.