### PR TITLE
Add support for sending `click` and `view` events from external sources

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,6 @@ services:
       INTERNAL_PORT: 80
       EXTERNAL_EVENT_API_KEY: ${EXTERNAL_EVENT_API_KEY}
       EXTERNAL_PORT: 11004
-      ACCOUNT_KEY: ${ACCOUNT_KEY-example}
       MONGO_DSN: ${MONGO_DSN-mongodb://mongodb:27017/parcel-plug-example}
     depends_on:
       - mongodb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     environment:
       <<: *env
       INTERNAL_PORT: 80
+      EXTERNAL_EVENT_API_KEY: ${EXTERNAL_EVENT_API_KEY}
       EXTERNAL_PORT: 11004
       ACCOUNT_KEY: ${ACCOUNT_KEY-example}
       MONGO_DSN: ${MONGO_DSN-mongodb://mongodb:27017/parcel-plug-example}

--- a/services/delivery/src/deliver/events.js
+++ b/services/delivery/src/deliver/events.js
@@ -49,6 +49,8 @@ const aggregateEvent = async ({
 };
 
 module.exports = {
+  getAdIds,
+  aggregateEvent,
   async view(adunit, correlator, adId, {
     now,
     email,

--- a/services/delivery/src/deliver/events.js
+++ b/services/delivery/src/deliver/events.js
@@ -25,12 +25,14 @@ const aggregateEvent = async ({
   publisherId,
 
   now,
+  external = false,
 }) => {
   const day = dayjs.tz(now, 'America/Chicago').format('YYYY-MM-DD');
   const _id = {
     ad: adId,
     adunit: adunitId,
     day,
+    ...(external && { external: true }),
   };
 
   return db.collection('events/aggregated').updateOne({ _id }, {

--- a/services/delivery/src/env.js
+++ b/services/delivery/src/env.js
@@ -3,6 +3,7 @@ const {
   makeValidator,
   port,
   bool,
+  str,
 } = require('envalid');
 
 const nonemptystr = makeValidator((v) => {
@@ -19,6 +20,7 @@ module.exports = cleanEnv(process.env, {
   MONGO_DSN: nonemptystr({ desc: 'The MongoDB DSN to connect to.' }),
   INTERNAL_PORT: port({ desc: 'The internal port that express will run on.', default: 80 }),
   EXTERNAL_PORT: port({ desc: 'The external port that express is exposed on.', default: 80 }),
+  EXTERNAL_EVENT_API_KEY: str({ desc: 'The external event API key to check.' }),
   CDN_HOST: nonemptystr({ desc: 'The CDN hostname for serving ad images.', default: 'cdn.email-x.parameter1.com' }),
   NEW_RELIC_ENABLED: bool({ desc: 'Whether New Relic is enabled.', default: true, devDefault: false }),
   NEW_RELIC_LICENSE_KEY: nonemptystr({ desc: 'The license key for New Relic.', devDefault: '(unset)' }),

--- a/services/delivery/src/routes/event.js
+++ b/services/delivery/src/routes/event.js
@@ -1,0 +1,45 @@
+const { asyncRoute, getAdUnit } = require('../utils');
+const events = require('../deliver/events.js');
+const { EXTERNAL_EVENT_API_KEY } = require('../env.js');
+
+module.exports = (app) => {
+  app.get('/event/:action(click|view)', asyncRoute(async (req, res) => {
+    const apiKey = req.get('x-api-key');
+    if (!EXTERNAL_EVENT_API_KEY) {
+      const error = new Error('No event API key has been configured.');
+      error.statusCode = 500;
+      throw error;
+    }
+    if (!apiKey) {
+      const error = new Error('No API key was provided.');
+      error.statusCode = 400;
+      throw error;
+    }
+    if (EXTERNAL_EVENT_API_KEY !== apiKey) {
+      const error = new Error('The provided API key is invalid.');
+      error.statusCode = 403;
+      throw error;
+    }
+
+    const { action } = req.params;
+    const { adId, adUnitId, date } = req.query;
+
+    const [adUnit, ids] = await Promise.all([
+      getAdUnit(adUnitId),
+      events.getAdIds(adId),
+    ]);
+
+    const { _id: adunitId, deploymentId, publisherId } = adUnit;
+    await events.aggregateEvent({
+      action,
+      ...ids,
+      adunitId,
+      deploymentId,
+      publisherId,
+      now: date,
+      external: true,
+    });
+
+    return res.send('OK');
+  }));
+};

--- a/services/delivery/src/routes/index.js
+++ b/services/delivery/src/routes/index.js
@@ -1,9 +1,11 @@
 const click = require('./click');
 const data = require('./data');
+const event = require('./event');
 const image = require('./image');
 
 module.exports = (app) => {
   click(app);
   data(app);
+  event(app);
   image(app);
 };


### PR DESCRIPTION
Mimics the aggregated event handling of the built-in ad delivery, but without the correlation or serving decisions of those endpoints. Aggregated events have `external: true` appended to their database identifiers so the data is segregated from events that are natively upserted (but will still appear in reports). This allows events to be sent independently of the delivery service.

The endpoint exists as `/event/:action` and requires that the external source provide an API key that matches the configured `EXTERNAL_EVENT_API_KEY` environment variable.